### PR TITLE
修复Android 10+中inline hook必然崩溃的问题

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
 
         ndk {
             abiFilters 'armeabi-v7a', 'arm64-v8a'

--- a/library/src/main/inline64/And64InlineHook.cpp
+++ b/library/src/main/inline64/And64InlineHook.cpp
@@ -583,6 +583,11 @@ extern "C" {
             if (trampoline == NULL) return;
         } //if
 
+        // Android 10 .text segment is read-only by default
+        if (0 != __make_rwx(symbol, 5 * sizeof(size_t))) {
+            return;
+        }
+
         trampoline = A64HookFunctionV(symbol, replace, trampoline, A64_MAX_INSTRUCTIONS * 10u);
         if (trampoline == NULL && result != NULL) {
             *result = NULL;


### PR DESCRIPTION
重现步骤：将targetSdkVersion更新为29（Android 10）后，直接编译运行工程，启动必然崩溃。
崩溃Log：com.bytedance.raphael.demo A/libc: Fatal signal 11 (SIGSEGV), code 2 (SEGV_ACCERR), fault addr 0x75df941344 in tid 2805 (ce.raphael.demo), pid 2805 (ce.raphael.demo)
崩溃栈：
```
(lldb) bt
* thread #1, name = 'ce.raphael.demo', stop reason = breakpoint 2.1
  * frame #0: 0x00000074ecb62db4 libraphael.so`__fix_branch_imm(inpp=0x0000007fc6a2f088, outpp=0x0000007fc6a2f080, ctxp=0x0000007fc6a2f090) at And64InlineHook.cpp:118:29
    frame #1: 0x00000074ecb62a3c libraphael.so`__fix_instructions(inp=0x00000075df941344, count=4, outp=0x00000074ecba1000) at And64InlineHook.cpp:450:17
    frame #2: 0x00000074ecb62694 libraphael.so`::A64HookFunctionV(symbol=0x00000075df941344, replace=0x00000074ecb74bd4, rwx=0x00000074ecba1000, rwx_size=50) at And64InlineHook.cpp:530:17
    frame #3: 0x00000074ecb62c80 libraphael.so`::A64HookFunction(symbol=0x00000075df941344, replace=0x00000074ecb74bd4, result=0x00000074ecb9f1f8) at And64InlineHook.cpp:586:22
    frame #4: 0x00000074ecb73624 libraphael.so`registerInlineProxy(env=0x000000755b6cfa40) at HookProxy.h:386:9
    frame #5: 0x00000074ecb7456c libraphael.so`Raphael::start(this=0x0000007542de9750, env=0x000000755b6cfa40, obj=0x0000007fc6a2f5a4, configs=13566976, space=0x0000007fc6a2f5a8, regex=0x0000000000000000) at Raphael.cpp:34:9
    frame #6: 0x00000074ecb75aec libraphael.so`start(env=0x000000755b6cfa40, obj=0x0000007fc6a2f5a4, configs=13566976, space=0x0000007fc6a2f5a8, regex=0x0000000000000000) at xloader.cpp:26:15
```

崩溃原因：
Android10或以上系统中，And64InlineHook.cpp:118中对指针inpp第2次取值时，其地址所在的vm_area_struct不具备可读（r）属性，系统发送型号SIGSEGV，导致App崩溃。

崩溃详情分析：
1. 本机运行得到*inapp的值为0x75df941344，此地址为libc.so中malloc函数地址
2. maps片段如图所示
![image](https://user-images.githubusercontent.com/286187/128860218-096e99f2-843f-440b-85e4-7a2a8cf25b4d.png)
3. 0x0003e000对应libc.so的.text .plt段（Segment），取出系统libc.so，readelf如图所示
![image](https://user-images.githubusercontent.com/286187/128860549-08d98871-ffe3-4466-b3f9-2fb07fd371b4.png)
4. 最后，通过mprotect调用更新vma属性即可。




