### PR TITLE
正则表达式使用扩展的正则表达式语法

### DIFF
--- a/library/src/main/cpp/PltGotHookProxy.h
+++ b/library/src/main/cpp/PltGotHookProxy.h
@@ -322,7 +322,7 @@ int registerSoLoadProxy(JNIEnv *env, jstring focused) {
 
     if (focused != NULL) {
         const char *focused_reg = (char *) env->GetStringUTFChars(focused, 0);
-        use_regex = regcomp(&focused_regex, focused_reg, REG_NOSUB) == 0;
+        use_regex = regcomp(&focused_regex, focused_reg, REG_EXTENDED|REG_NOSUB) == 0;
         env->ReleaseStringUTFChars(focused, focused_reg);
     }
 


### PR DESCRIPTION
当我使用 .*lib(hwui|android_runtime)\.so$ 这样的正则表达式去同时关注多个 so 的时候无法生效，因为默认的只支持标准的正则表达式语法。