### PR TITLE
Android 12 exported

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
 
     <application>
         <receiver
-            android:name="com.bytedance.raphael.RaphaelReceiver">
+            android:name="com.bytedance.raphael.RaphaelReceiver"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="com.bytedance.raphael.ACTION_START" />


### PR DESCRIPTION
Android12适配

INSTALL_PARSE_FAILED_MANIFEST_MALFORMED: Failed parse during installPackageLI: /data/app/vmdl1017191547.tmp/base.apk (at Binary XML file line #223): com.bytedance.raphael.RaphaelReceiver: Targeting S+ (version 31 and above) requires that an explicit value for android:exported be defined when intent filters are present
