### PR TITLE
在报告里面带上具体的分配函数

### DIFF
--- a/library/src/main/cpp/Cache.h
+++ b/library/src/main/cpp/Cache.h
@@ -42,9 +42,19 @@ typedef struct {
     uintptr_t         trace[MAX_TRACE_DEPTH];
 } Backtrace;
 
+enum ALLOC_FUNC {
+    MALLOC,
+    CALLOC,
+    REALLOC,
+    MEMALIGN,
+    MMAP,
+    MMAP64
+};
+
 struct AllocNode {
     uint32_t size;
     uintptr_t addr;
+    ALLOC_FUNC  func;
     uintptr_t trace[MAX_TRACE_DEPTH];
     AllocNode *next;
 };
@@ -55,7 +65,7 @@ public:
     virtual ~Cache() {}
 public:
     virtual void reset() = 0;
-    virtual void insert(uintptr_t address, size_t size, Backtrace *backtrace) = 0;
+    virtual void insert(uintptr_t address, size_t size, ALLOC_FUNC func, Backtrace *backtrace) = 0;
     virtual void remove(uintptr_t address) = 0;
     virtual void print() = 0;
 protected:

--- a/library/src/main/cpp/MemoryCache.h
+++ b/library/src/main/cpp/MemoryCache.h
@@ -21,14 +21,14 @@
 #include "AllocPool.hpp"
 
 #if defined(__LP64__)
-#define STACK_FORMAT_HEADER "\n0x%016lx, %u, 1\n"
+#define STACK_FORMAT_HEADER "\n0x%016lx, %u, %s, 1\n"
 #define STACK_FORMAT_UNKNOWN "0x%016lx <unknown>\n"
 #define STACK_FORMAT_ANONYMOUS "0x%016lx <anonymous:%016lx>\n"
 #define STACK_FORMAT_FILE "0x%016lx %s (unknown)\n"
 #define STACK_FORMAT_FILE_NAME "0x%016lx %s (%s + \?)\n"
 #define STACK_FORMAT_FILE_NAME_LINE "0x%016lx %s (%s + %lu)\n"
 #else
-#define STACK_FORMAT_HEADER "\n0x%08x, %u, 1\n"
+#define STACK_FORMAT_HEADER "\n0x%08x, %u, %s, 1\n"
 #define STACK_FORMAT_UNKNOWN "0x%08x <unknown>\n"
 #define STACK_FORMAT_ANONYMOUS "0x%08x <anonymous:%08x>\n"
 #define STACK_FORMAT_FILE "0x%08x %s (unknown)\n"
@@ -42,7 +42,7 @@ public:
     ~MemoryCache();
 public:
     void reset();
-    void insert(uintptr_t address, size_t size, Backtrace *backtrace);
+    void insert(uintptr_t address, size_t size, ALLOC_FUNC func, Backtrace *backtrace);
     void remove(uintptr_t address);
     void print();
 private:

--- a/library/src/main/python/raphael.py
+++ b/library/src/main/python/raphael.py
@@ -59,14 +59,17 @@ class Frame:
 
 
 class Trace:
-    def __init__(self, id, size, count, stack):
+    def __init__(self, id, size, func, count, stack):
         self.id    = id
         self.size  = int(size)
+        self.func  = func
         self.count = int(count)
         self.stack = stack
 
     def __eq__(self, b):
         if len(self.stack) != len(b.stack):
+            return False
+        if self.func != b.func:
             return False
         for i in range(0, len(self.stack)):
             if self.stack[i] != b.stack[i]:
@@ -152,7 +155,7 @@ def print_report(writer, report):
     for record in report:
         retry_symbol(record)
 
-        writer.write('\n%s, %s, %s\n' % (record.id, record.size, record.count))
+        writer.write('\n%s, %s, %s, %s\n' % (record.id, record.size, record.func, record.count))
         for frame in record.stack:
             writer.write('%s %s (%s)\n' % (frame.pc, frame.path, frame.desc))
 
@@ -182,8 +185,8 @@ def parse_report(string):
         stack = []
         for frame in match:
             stack.append(Frame(frame[0], frame[1], frame[2]))
-        match = re.compile(r'(0x[0-9a-f]+),\ (\d+),\ (\d+)$', re.M | re.I).findall(split)
-        report.append(Trace(match[0][0], match[0][1], match[0][2], stack))
+        match = re.compile(r'(0x[0-9a-f]+),\ (\d+),\ (\S+),\ (\d+)$', re.M | re.I).findall(split)
+        report.append(Trace(match[0][0], match[0][1], match[0][2], match[0][3], stack))
     return report
 
 


### PR DESCRIPTION
目前堆栈里面，是没有对应的分配函数的，在采集和报告合并的时候都带上。这个的目的主要是为了区分 malloc 类和 mmap 类。