### PR TITLE
update:提供c++ api,使得Raphael能够在native c++命令行程序或者so中使用

### DIFF
--- a/library/src/main/cpp/HookProxy.h
+++ b/library/src/main/cpp/HookProxy.h
@@ -369,7 +369,7 @@ void registerPltGotProxy(JNIEnv *env, jstring regex) {
     }
 }
 
-void registerInlineProxy(JNIEnv *env) {
+void registerInlineProxy() {
     invoke_je_free();
 
     const int PROXY_MAPPING_LENGTH = sizeof(sInline) / sizeof(sInline[0]);

--- a/library/src/main/cpp/PltGotHookProxy.h
+++ b/library/src/main/cpp/PltGotHookProxy.h
@@ -317,13 +317,12 @@ static void try_pltgot_hook_on_soload(const char *filename) {
     }
 }
 
-int registerSoLoadProxy(JNIEnv *env, jstring focused) {
+int registerSoLoadProxy(const char* focused) {
     api_level = android_get_device_api_level();
 
     if (focused != NULL) {
-        const char *focused_reg = (char *) env->GetStringUTFChars(focused, 0);
+        const char *focused_reg = focused;
         use_regex = regcomp(&focused_regex, focused_reg, REG_EXTENDED|REG_NOSUB) == 0;
-        env->ReleaseStringUTFChars(focused, focused_reg);
     }
 
     if (api_level >= __ANDROID_API_N__ && api_level < __ANDROID_API_O__) {

--- a/library/src/main/cpp/Raphael.h
+++ b/library/src/main/cpp/Raphael.h
@@ -17,24 +17,27 @@
 #ifndef RAPHAEL_H
 #define RAPHAEL_H
 
-#include <jni.h>
-#include "Cache.h"
+#include <string>
+
+
+#define RAPHAEL_API __attribute__((visibility("default")))
+
 
 #define MAP64_MODE 0x00800000
 #define ALLOC_MODE 0x00400000
 #define DEPTH_MASK 0x001F0000
 #define LIMIT_MASK 0x0000FFFF
-
-class Raphael {
+class Cache;
+class RAPHAEL_API Raphael {
 public:
-    void start(JNIEnv *env, jobject obj, jint configs, jstring space, jstring regex);
-    void stop(JNIEnv *env, jobject obj);
-    void print(JNIEnv *env, jobject obj);
+    void start(int configs, const char* space, const char* regex);
+    void stop();
+    void print();
 private:
-    void clean_cache(JNIEnv *env);
-    void dump_system(JNIEnv *env);
+    void clean_cache();
+    void dump_system();
 private:
-    char  *mSpace;
+    std::string mSpace;
     Cache *mCache;
 };
 

--- a/library/src/main/cpp/xloader.cpp
+++ b/library/src/main/cpp/xloader.cpp
@@ -23,15 +23,22 @@
 Raphael* sRaphael = new Raphael();
 
 void start(JNIEnv *env, jobject obj, jint configs, jstring space, jstring regex) {
-    sRaphael->start(env, obj, configs, space, regex);
+    const char *spacestring = (char *) env->GetStringUTFChars(space, 0);
+
+    const char *regexstring = (char *) env->GetStringUTFChars(regex, 0);
+
+    sRaphael->start(configs, spacestring, regexstring);
+
+    env->ReleaseStringUTFChars(space, spacestring);
+    env->ReleaseStringUTFChars(regex, regexstring);
 }
 
 void stop(JNIEnv *env, jobject obj) {
-    sRaphael->stop(env, obj);
+    sRaphael->stop();
 }
 
 void print(JNIEnv *env, jobject obj) {
-    sRaphael->print(env, obj);
+    sRaphael->print();
 }
 
 static const JNINativeMethod sMethods[] = {


### PR DESCRIPTION
提供c++ api,使得Raphael能够在native c++命令行程序或者so中使用.
1. 修改Raphael.h,移除jni依赖，可作为独立c++ api header.
2. jni参数获取移入xloader.cpp,做为独立的java/jni-c++接口绑定层。