### PR TITLE
python脚本windows平台修正

### DIFF
--- a/library/src/main/python/mmap.py
+++ b/library/src/main/python/mmap.py
@@ -26,7 +26,7 @@ __PATTERN__ = re.compile(r'(\S+)-(\S+) \S+ \S+ \S+ (\d+)\s*(.*)$')
 
 
 def analyse(name):
-    reader = open(name, 'r')
+    reader = open(name, 'r', encoding = 'utf-8')
     totals = 0
     detail = {}
     for line in reader.readlines():

--- a/library/src/main/python/raphael.py
+++ b/library/src/main/python/raphael.py
@@ -211,7 +211,7 @@ if __name__ == '__main__':
     else:
         parse_symbol(argParams.symbol)
 
-    reader = open(argParams.report)
+    reader = open(argParams.report, encoding = 'utf-8')
     string = reader.read()
     reader.close()
 


### PR DESCRIPTION
由于安卓的文件写出编码就是utf-8，因此应该设置文件读取编码为utf-8，如果不设置，部分输出结果在windows下可能输出“'gbk' codec can't decode byte 0xad in position”